### PR TITLE
Allows authentication without "users" table.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 .php_cs.cache
 coverage
 .phpunit.result.cache
+docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ This package helps you authenticate users on a Laravel API based on JWT tokens g
 
 ✔️ I will not use Laravel Passport for authentication, because Keycloak Server will do the job.
 
-✔️ I already have an "users table", with unique identifiers, on my database.
-
 ✔️ The frontend is a separated project.
 
 ✔️ The frontend users authenticate **directly on Keycloak Server** to obtain a JWT token. This process have nothing to do with the Laravel API.
@@ -81,6 +79,8 @@ The Keycloak Guard configuration can be handled from Laravel `.env` file. ⚠️
 return [  
   'realm_public_key' => env('KEYCLOAK_REALM_PUBLIC_KEY', null),
 
+  'load_user_from_database' => env('KEYCLOAK_LOAD_USER_FROM_DATABASE', true),
+
   'user_provider_credential' => env('KEYCLOAK_USER_PROVIDER_CREDENTIAL', 'username'),
 
   'token_principal_attribute' => env('KEYCLOAK_TOKEN_PRINCIPAL_ATTRIBUTE', 'preferred_username'),
@@ -98,12 +98,20 @@ return [
 
 The Keycloak Server realm public key (string).
 
+✔️ **load_user_from_database**
+
+*Required. Default is `true`.*
+
+If you do not have an `users` table you must disable this.
+
+It fetchs user from database and fill values into authenticated user object. If enabled, it will work together with `user_provider_credential` and `user_provider_credential`.
+
 ✔️ **user_provider_credential**
 
 *Required. Default is `username`.*
 
 
-Any field from "users" table that contains the user unique identifier (eg.  username, email, nickname). This will be confronted against  `token_principal_attribute` attribute, while authenticating.
+The field from "users" table that contains the user unique identifier (eg.  username, email, nickname). This will be confronted against  `token_principal_attribute` attribute, while authenticating.
 
 ✔️ **token_principal_attribute**
 

--- a/config/keycloak.php
+++ b/config/keycloak.php
@@ -3,6 +3,8 @@
 return [
   'realm_public_key' => env('KEYCLOAK_REALM_PUBLIC_KEY', null),
 
+  'load_user_from_database' => env('KEYCLOAK_LOAD_USER_FROM_DATABASE', true),
+
   'user_provider_credential' => env('KEYCLOAK_USER_PROVIDER_CREDENTIAL', 'username'),
 
   'token_principal_attribute' => env('KEYCLOAK_TOKEN_PRINCIPAL_ATTRIBUTE', 'preferred_username'),

--- a/src/KeycloakGuard.php
+++ b/src/KeycloakGuard.php
@@ -123,10 +123,15 @@ class KeycloakGuard implements Guard
 
     $this->validateResources();
 
-    $user = $this->provider->retrieveByCredentials($credentials);
+    if ($this->config['load_user_from_database']) {
+      $user = $this->provider->retrieveByCredentials($credentials);
 
-    if (!$user) {
-      throw new UserNotFoundException("User not found. Credentials: " . json_encode($credentials));
+      if (!$user) {
+        throw new UserNotFoundException("User not found. Credentials: " . json_encode($credentials));
+      }
+    } else {
+      $class = $this->provider->getModel();
+      $user = new $class();
     }
 
     $this->setUser($user);
@@ -173,21 +178,22 @@ class KeycloakGuard implements Guard
   }
 
   /**
-  * Check if authenticated user has a especific role into resource
-  * @param string $resource
-  * @param string $role
-  * @return bool
-  */
-  public function hasRole($resource, $role) {
-     $token_resource_access = (array) $this->decodedToken->resource_access;
-     if(array_key_exists($resource, $token_resource_access)) {
-         $token_resource_values = (array)$token_resource_access[$resource];
+   * Check if authenticated user has a especific role into resource
+   * @param string $resource
+   * @param string $role
+   * @return bool
+   */
+  public function hasRole($resource, $role)
+  {
+    $token_resource_access = (array)$this->decodedToken->resource_access;
+    if (array_key_exists($resource, $token_resource_access)) {
+      $token_resource_values = (array)$token_resource_access[$resource];
 
-         if(array_key_exists('roles', $token_resource_values) &&
-             in_array($role, $token_resource_values['roles'])) {
-             return true;
-         }
-     }
-     return false;
+      if (array_key_exists('roles', $token_resource_values) &&
+        in_array($role, $token_resource_values['roles'])) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/tests/AuthenticateTest.php
+++ b/tests/AuthenticateTest.php
@@ -87,15 +87,37 @@ class AuthenticateTest extends TestCase
   }
 
   /** @test */
+  public function it_does_not_load_user_from_database()
+  {
+    config(['keycloak.load_user_from_database' => false]);
+
+    $response = $this->withToken()->json('GET', '/foo/secret');
+
+    $this->assertEquals(count(Auth::user()->getAttributes()), 0);
+  }
+
+  /** @test */
+  public function it_does_not_load_user_from_database_but_appends_decoded_token()
+  {
+    config(['keycloak.load_user_from_database' => false]);
+    config(['keycloak.append_decoded_token' => true]);
+
+    $response = $this->withToken()->json('GET', '/foo/secret');
+
+    $this->assertArrayHasKey('token', Auth::user()->toArray());
+  }
+
+
+  /** @test */
   public function it_check_user_has_role_in_resource()
   {
     $this->buildCustomToken([
       'resource_access' => [
         'myapp-backend' => [
-            'roles' => [
-              'myapp-backend-role1',
-              'myapp-backend-role2'
-            ]
+          'roles' => [
+            'myapp-backend-role1',
+            'myapp-backend-role2'
+          ]
         ],
         'myapp-frontend' => [
           'roles' => [
@@ -116,10 +138,10 @@ class AuthenticateTest extends TestCase
     $this->buildCustomToken([
       'resource_access' => [
         'myapp-backend' => [
-            'roles' => [
-              'myapp-backend-role1',
-              'myapp-backend-role2'
-            ]
+          'roles' => [
+            'myapp-backend-role1',
+            'myapp-backend-role2'
+          ]
         ],
         'myapp-frontend' => [
           'roles' => [
@@ -140,10 +162,10 @@ class AuthenticateTest extends TestCase
     $this->buildCustomToken([
       'resource_access' => [
         'myapp-backend' => [
-            'roles' => [
-              'myapp-backend-role1',
-              'myapp-backend-role2'
-            ]
+          'roles' => [
+            'myapp-backend-role1',
+            'myapp-backend-role2'
+          ]
         ],
         'myapp-frontend' => [
           'roles' => [


### PR DESCRIPTION
✔️ **load_user_from_database**

*Required. Default is `true`.*

If you do not have an `users` table you must disable this.

It fetchs user from database and fill values into authenticated user object. If enabled, it will work together with `user_provider_credential` and `user_provider_credential`.
