### PR TITLE
Proper handling of token without resource_access

### DIFF
--- a/src/KeycloakGuard.php
+++ b/src/KeycloakGuard.php
@@ -159,7 +159,7 @@ class KeycloakGuard implements Guard
    */
   private function validateResources()
   {
-    $token_resource_access = array_keys((array)$this->decodedToken->resource_access);
+    $token_resource_access = array_keys((array)($this->decodedToken->resource_access ?? []));
     $allowed_resources = explode(',', $this->config['allowed_resources']);
 
     if (count(array_intersect($token_resource_access, $allowed_resources)) == 0) {

--- a/tests/AuthenticateTest.php
+++ b/tests/AuthenticateTest.php
@@ -15,7 +15,7 @@ use KeycloakGuard\Exceptions\ResourceAccessNotAllowedException;
 class AuthenticateTest extends TestCase
 {
 
-  protected function setUp()
+  protected function setUp() : void
   {
     parent::setUp();
   }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,7 +12,7 @@ use Illuminate\Auth\Middleware\Authenticate;
 
 class TestCase extends Orchestra
 {
-  protected function setUp()
+  protected function setUp() : void
   {
     parent::setUp();    
     


### PR DESCRIPTION
- handle the scenario when JWT has no `resource_access` defined (instead of `Undefined property: stdClass::$resource_access`)