### PR TITLE
Remove return from setUser method

### DIFF
--- a/src/KeycloakGuard.php
+++ b/src/KeycloakGuard.php
@@ -148,8 +148,6 @@ class KeycloakGuard implements Guard
   public function setUser(Authenticatable $user)
   {
     $this->user = $user;
-
-    return $this;
   }
 
   /**


### PR DESCRIPTION
Method signature says that it returns nothing - `void`.