### PR TITLE
Remove throwing exception to support multiple guards.

### DIFF
--- a/src/KeycloakGuard.php
+++ b/src/KeycloakGuard.php
@@ -125,16 +125,14 @@ class KeycloakGuard implements Guard
 
     if ($this->config['load_user_from_database']) {
       $user = $this->provider->retrieveByCredentials($credentials);
-
-      if (!$user) {
-        throw new UserNotFoundException("User not found. Credentials: " . json_encode($credentials));
-      }
     } else {
       $class = $this->provider->getModel();
       $user = new $class();
     }
 
-    $this->setUser($user);
+    if ($user) {
+        $this->setUser($user);
+    }
 
     return true;
   }


### PR DESCRIPTION
Example auth:api,old_api
Laravel throws an exception if the user is not found in the database.