### PR TITLE
feat: support token via query param or input key

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,3 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
-
-[*.md]
-trim_trailing_whitespace = false
-

--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ Appends to the authenticated user the full decoded JWT token (`$user->token`). U
 
 Usually you API should handle one *resource_access*. But, if you handle multiples, just use a comma separated list of allowed resources accepted by API. This attribute will be confronted against `resource_access` attribute from JWT token, while authenticating.
 
+✔️ **input_key**
+
+*Default is `api_token`.*
+
+The name of the query string item from the request containing the API token.
+
 ## Laravel Auth
 
 Changes on `config/auth.php`

--- a/config/keycloak.php
+++ b/config/keycloak.php
@@ -1,10 +1,10 @@
-<?php 
+<?php
 
 return [
   'realm_public_key' => env('KEYCLOAK_REALM_PUBLIC_KEY', null),
 
   'load_user_from_database' => env('KEYCLOAK_LOAD_USER_FROM_DATABASE', true),
-  
+
   'user_provider_custom_retrieve_method' => null,
 
   'user_provider_credential' => env('KEYCLOAK_USER_PROVIDER_CREDENTIAL', 'username'),
@@ -13,5 +13,7 @@ return [
 
   'append_decoded_token' => env('KEYCLOAK_APPEND_DECODED_TOKEN', false),
 
-  'allowed_resources' => env('KEYCLOAK_ALLOWED_RESOURCES', null)
+  'allowed_resources' => env('KEYCLOAK_ALLOWED_RESOURCES', null),
+
+  'input_key' => env('KEYCLOAK_TOKEN_INPUT_KEY', 'api_token'),
 ];

--- a/src/KeycloakGuard.php
+++ b/src/KeycloakGuard.php
@@ -16,14 +16,13 @@ class KeycloakGuard implements Guard
   private $provider;
   private $decodedToken;
 
-  public function __construct(UserProvider $provider, Request $request, string $inputKey = 'api_token')
+  public function __construct(UserProvider $provider, Request $request)
   {
     $this->config = config('keycloak');
     $this->user = null;
     $this->provider = $provider;
     $this->decodedToken = null;
     $this->request = $request;
-    $this->inputKey = $inputKey;
 
     $this->authenticate();
   }
@@ -56,10 +55,12 @@ class KeycloakGuard implements Guard
    */
   public function getTokenForRequest()
   {
-    $token = $this->request->query($this->inputKey);
+    $inputKey = $this->config['input_key'] ?? 'api_token';
+
+    $token = $this->request->query($inputKey);
 
     if (empty($token)) {
-      $token = $this->request->input($this->inputKey);
+      $token = $this->request->input($inputKey);
     }
 
     if (empty($token)) {

--- a/src/KeycloakGuardServiceProvider.php
+++ b/src/KeycloakGuardServiceProvider.php
@@ -20,8 +20,7 @@ class KeycloakGuardServiceProvider extends ServiceProvider
     Auth::extend('keycloak', function ($app, $name, array $config) {
       return new KeycloakGuard(
         Auth::createUserProvider($config['provider']),
-        $app->request,
-        $config['input_key'] ?? 'api_token'
+        $app->request
       );
     });
   }

--- a/src/KeycloakGuardServiceProvider.php
+++ b/src/KeycloakGuardServiceProvider.php
@@ -18,7 +18,11 @@ class KeycloakGuardServiceProvider extends ServiceProvider
   public function register()
   {
     Auth::extend('keycloak', function ($app, $name, array $config) {
-      return new KeycloakGuard(Auth::createUserProvider($config['provider']), $app->request);
+      return new KeycloakGuard(
+        Auth::createUserProvider($config['provider']),
+        $app->request,
+        $config['input_key'] ?? 'api_token'
+      );
     });
   }
 }

--- a/tests/AuthenticateTest.php
+++ b/tests/AuthenticateTest.php
@@ -47,6 +47,19 @@ class AuthenticateTest extends TestCase
   }
 
   /** @test */
+  public function it_authenticates_the_user_when_request_any_endpoint_with_query_token_custom_input_key()
+  {
+    config(['keycloak.input_key' => 'token']);
+    $this->json('GET', '/foo/secret?token=' . $this->token);
+
+    $this->assertEquals($this->user->username, Auth::user()->username);
+
+    $this->json('GET', '/foo/public');
+
+    $this->assertEquals($this->user->username, Auth::user()->username);
+  }
+
+  /** @test */
   public function it_authenticates_the_user_when_request_any_endpoint_with_input_token()
   {
     $this->json('POST', '/foo/secret', ['api_token' => $this->token]);

--- a/tests/AuthenticateTest.php
+++ b/tests/AuthenticateTest.php
@@ -35,6 +35,30 @@ class AuthenticateTest extends TestCase
   }
 
   /** @test */
+  public function it_authenticates_the_user_when_request_any_endpoint_with_query_token()
+  {
+    $this->json('GET', '/foo/secret?api_token=' . $this->token);
+
+    $this->assertEquals($this->user->username, Auth::user()->username);
+
+    $this->json('GET', '/foo/public');
+
+    $this->assertEquals($this->user->username, Auth::user()->username);
+  }
+
+  /** @test */
+  public function it_authenticates_the_user_when_request_any_endpoint_with_input_token()
+  {
+    $this->json('POST', '/foo/secret', ['api_token' => $this->token]);
+
+    $this->assertEquals($this->user->username, Auth::user()->username);
+
+    $this->json('GET', '/foo/public');
+
+    $this->assertEquals($this->user->username, Auth::user()->username);
+  }
+
+  /** @test */
   public function it_forbiden_when_request_a_protected_endpoint_without_token()
   {
     $response = $this->json('GET', '/foo/secret');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -105,4 +105,5 @@ class TestCase extends Orchestra
 
     return $this;
   }
+
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -46,6 +46,7 @@ class TestCase extends Orchestra
     config(['keycloak.token_principal_attribute' => 'preferred_username']);
     config(['keycloak.append_decoded_token' => false]);
     config(['keycloak.allowed_resources' => 'myapp-backend']);
+    config(['keycloak.input_key' => 'api_token']);
 
     // bootstrap 
 


### PR DESCRIPTION
*Hi,  I could not find if this issue has been discussed before.*

### Synopsis
Currently this project only supports sending the access token via authorization header (bearer token). I have a use case where we also need to support sending the access token via query param / form input. 

### Solution
This PR allows sending the access token via a get query param or from the input data. 
The solution is based on the default Laravel [TokenGuard](https://github.com/laravel/framework/blob/1bbe5528568555d597582fdbec73e31f8a818dbc/src/Illuminate/Auth/TokenGuard.php#L97).

 * Supports sending the access token via a query param (default `api_token`)
 * Supports sending the access token via an input param (default `api_token`) - i.e. a form post

The `api_token` param can be set via the configuration using the key `input_key`.

### Could have
Possibly can be enhanced to allow disabling (or opt in) via config.

---
Fixes #63