### PR TITLE
add functionality of checking the user permission

### DIFF
--- a/src/KeycloakGuard.php
+++ b/src/KeycloakGuard.php
@@ -199,4 +199,52 @@ class KeycloakGuard implements Guard
     }
     return false;
   }
+
+  /**
+   * Check if authenticated user has a especific permission into resource
+   * @param string $resource
+   * @param string $permission
+   * @return bool
+   */
+  public function hasPermission($resource, $permission)
+  {
+
+
+    $token = request()->bearerToken();
+
+
+    $key_url = "http://127.0.0.1:8080/auth/";
+    $realm = "your-realm";
+
+    //this two variables need to add to the config file and set as env variables to be able to change easily
+
+    $tokenUrl = $key_url . 'realms/' .  $realm . '/protocol/openid-connect/token';
+    
+    $headers = ['Authorization' => 'Bearer ' . $token];
+
+    $formData = [
+      "grant_type" => "urn:ietf:params:oauth:grant-type:uma-ticket",
+      "audience" => $resource,
+      'permission' => $permission,
+      'response_mode' => "decision",
+    ];
+
+
+    try {
+      $client = new \GuzzleHttp\Client();
+
+      $request = $client->post($tokenUrl, [
+        'headers' => $headers,
+        'form_params' => $formData,
+      ]);
+
+      $response = $request->getBody();
+      $response  = (array)json_decode($response);
+
+      return isset($response["result"]) ? $response["result"] : false;
+    } catch (\Exception $e) {
+      return false;
+    }
+  }
 }
+


### PR DESCRIPTION
this will allow you to check permission like that 

 Auth::hasPermission('trumobile-api', 'drivers#driver-index');

as mentioned in the keylock documentation link  
https://www.keycloak.org/docs/latest/authorization_services/index.html#_service_obtaining_permissions 

through curl request, we make an HTTP call to the keylock server 

curl -X POST \
  http://${host}:${port}/realms/${realm}/protocol/openid-connect/token \
  -H "Authorization: Bearer ${access_token}" \
  --data "grant_type=urn:ietf:params:oauth:grant-type:uma-ticket" \
  --data "audience={resource_server_client_id}" \
  --data "permission=Resource A#Scope A" \
  --data "permission=Resource B#Scope B"