### PR TITLE
allow the KeycloakGuard to be extended

### DIFF
--- a/src/KeycloakGuard.php
+++ b/src/KeycloakGuard.php
@@ -12,11 +12,11 @@ use KeycloakGuard\Exceptions\UserNotFoundException;
 
 class KeycloakGuard implements Guard
 {
-    private $config;
-    private $user;
-    private $provider;
-    private $decodedToken;
-    private Request $request;
+    protected $config;
+    protected $user;
+    protected $provider;
+    protected $decodedToken;
+    protected Request $request;
 
     public function __construct(UserProvider $provider, Request $request)
     {
@@ -34,7 +34,7 @@ class KeycloakGuard implements Guard
      *
      * @return mixed
      */
-    private function authenticate()
+    protected function authenticate()
     {
         try {
             $this->decodedToken = Token::decode($this->getTokenForRequest(), $this->config['realm_public_key'], $this->config['leeway']);
@@ -179,7 +179,7 @@ class KeycloakGuard implements Guard
      *
      * @return void
      */
-    private function validateResources()
+    protected function validateResources()
     {
         if ($this->config['ignore_resources_validation']) {
             return;


### PR DESCRIPTION
This is the same PR as https://github.com/robsontenorio/laravel-keycloak-guard/pull/84 which was closed because the author removed his/her fork.

Please (re)consider merging this PR since it would close #81 and help people (such as me) to extend the capabilities of the KeycloakGuard.

I tested locally and all tests were still working.

```
% composer test
> pest

   PASS  KeycloakGuard\Tests\AuthenticateTest
  ✓ authenticates the user when requesting a private endpoint with token
  ✓ authenticates the user when requesting an public endpoint with token
  ✓ forbiden when request a protected endpoint without token
  ✓ laravel default interface for authenticated users
  ✓ laravel default interface for unathenticated users
  ✓ throws a exception when user is not found
  ✓ appends token to the user
  ✓ does not appends token to the user
  ✓ does not load user from database
  ✓ does not load user from database but appends decoded token
  ✓ throws a exception when resource access is not allowed by api
  ✓ ignores resources validation
  ✓ check user has role in resource
  ✓ check user no has role in resource
  ✓ prevent cross roles resources
  ✓ check user has any role in resource
  ✓ check user no has any role in resource
  ✓ prevent cross roles resources with any role
  ✓ custom user retrieve method
  ✓ throws a exception with invalid iat
  ✓ works with leeway
  ✓ authenticates with custom input key
  ✓ authentication prefers bearer token over with custom input key

  Tests:  23 passed
  Time:   0.50s
```