### PR TITLE
Acting as a Keycloak user in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,22 @@ Auth::hasAnyRole('myapp-frontend', ['myapp-frontend-role1', 'myapp-frontend-role
 Auth::hasAnyRole('myapp-backend', ['myapp-frontend-role1', 'myapp-frontend-role2']) // false
 ```
 
+# Acting as a Keycloak user in tests
+
+As an equivelant feature like `$this->actingAs($user)` in Laravel, with this package you can use `KeycloakGuard\ActingAsKeycloakUser` trait in your test class and then use `actingAsKeycloakUser()` method to act as a user and somehow skip the Keycloak auth:
+
+```php
+use KeycloakGuard\ActingAsKeycloakUser;
+
+public test_a_protected_route()
+{
+    $this->actingAsKeycloakUser()
+        ->getJson('/api/somewhere')
+        ->assertOk();
+}
+```
+
+
 # Contribute
 
 You can run this project on VSCODE with Remote Container. Make sure you will use internal VSCODE terminal (inside running container).

--- a/src/ActingAsKeycloakUser.php
+++ b/src/ActingAsKeycloakUser.php
@@ -9,9 +9,13 @@ trait ActingAsKeycloakUser
 {
     public function actingAsKeycloakUser($user = null)
     {
+        if (!$user) {
+            Config::set('keycloak.load_user_from_database', false);
+        }
+
         $token = $this->generateKeycloakToken($user);
 
-        $this->withHeader('Authorization', 'Bearer ' . $token);
+        $this->withHeader('Authorization', 'Bearer '.$token);
 
         return $this;
     }
@@ -26,7 +30,7 @@ trait ActingAsKeycloakUser
 
         $publicKey = openssl_pkey_get_details($privateKey)['key'];
 
-        $publicKey = str_replace(["\n", '-----BEGIN PUBLIC KEY-----', '-----END PUBLIC KEY-----'], '', $publicKey);
+        $publicKey = Token::plainPublicKey($publicKey);
 
         Config::set('keycloak.realm_public_key', $publicKey);
 

--- a/src/ActingAsKeycloakUser.php
+++ b/src/ActingAsKeycloakUser.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace KeycloakGuard;
+
+use Firebase\JWT\JWT;
+use Illuminate\Support\Facades\Config;
+
+trait ActingAsKeycloakUser
+{
+    public function actingAsKeycloakUser($user = null)
+    {
+        $token = $this->generateKeycloakToken($user);
+
+        $this->withHeader('Authorization', 'Bearer ' . $token);
+
+        return $this;
+    }
+
+    public function generateKeycloakToken($user = null)
+    {
+        $privateKey = openssl_pkey_new([
+            'digest_alg' => 'sha256',
+            'private_key_bits' => 1024,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA
+        ]);
+
+        $publicKey = openssl_pkey_get_details($privateKey)['key'];
+
+        $publicKey = str_replace(["\n", '-----BEGIN PUBLIC KEY-----', '-----END PUBLIC KEY-----'], '', $publicKey);
+
+        Config::set('keycloak.realm_public_key', $publicKey);
+
+        $payload = [
+            'preferred_username' => $user->username ?? config('keycloak.preferred_username'),
+            'resource_access' => [config('keycloak.allowed_resources') => []]
+        ];
+
+        $token = JWT::encode($payload, $privateKey, 'RS256');
+
+        return $token;
+    }
+}

--- a/src/Token.php
+++ b/src/Token.php
@@ -32,4 +32,19 @@ class Token
     {
         return "-----BEGIN PUBLIC KEY-----\n".wordwrap($key, 64, "\n", true)."\n-----END PUBLIC KEY-----";
     }
+
+    /**
+     * Get the plain public key from a string
+     *
+     * @param  string  $key
+     * @return string
+     */
+    public static function plainPublicKey(string $key): string
+    {
+        $string = str_replace('-----BEGIN PUBLIC KEY-----', '', $key);
+        $string = trim(str_replace('-----END PUBLIC KEY-----', '', $string));
+        $string = str_replace('\n', '', $string);
+
+        return $string;
+    }
 }

--- a/tests/AuthenticateTest.php
+++ b/tests/AuthenticateTest.php
@@ -5,6 +5,7 @@ namespace KeycloakGuard\Tests;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Hashing\BcryptHasher;
 use Illuminate\Support\Facades\Auth;
+use KeycloakGuard\ActingAsKeycloakUser;
 use KeycloakGuard\Exceptions\ResourceAccessNotAllowedException;
 use KeycloakGuard\Exceptions\TokenException;
 use KeycloakGuard\Exceptions\UserNotFoundException;
@@ -14,6 +15,8 @@ use KeycloakGuard\Tests\Models\User;
 
 class AuthenticateTest extends TestCase
 {
+    use ActingAsKeycloakUser;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -340,4 +343,12 @@ class AuthenticateTest extends TestCase
 
         $this->json('POST', '/foo/secret', ['api_token' => $this->token]);
     }
+
+    public function test_with_keycloak_token_trait()
+    {
+        $this->actingAsKeycloakUser($this->user)->json('GET', '/foo/secret');
+
+        $this->assertEquals($this->user->username, Auth::user()->username);
+    }
+
 }

--- a/tests/AuthenticateTest.php
+++ b/tests/AuthenticateTest.php
@@ -351,4 +351,13 @@ class AuthenticateTest extends TestCase
         $this->assertEquals($this->user->username, Auth::user()->username);
     }
 
+    public function test_acting_as_keycloak_user_trait_without_user()
+    {
+        $this->actingAsKeycloakUser()->json('GET', '/foo/secret');
+
+        $this->assertTrue(Auth::hasUser());
+
+        $this->assertFalse(Auth::guest());
+    }
+
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Route;
 use KeycloakGuard\KeycloakGuardServiceProvider;
 use KeycloakGuard\Tests\Factories\UserFactory;
 use KeycloakGuard\Tests\Models\User;
+use KeycloakGuard\Token;
 use OpenSSLAsymmetricKey;
 use Orchestra\Testbench\TestCase as Orchestra;
 
@@ -68,7 +69,7 @@ class TestCase extends Orchestra
         ]);
 
         $app['config']->set('keycloak', [
-            'realm_public_key' => $this->plainPublicKey(),
+            'realm_public_key' => Token::plainPublicKey($this->publicKey),
             'user_provider_credential' => 'username',
             'token_principal_attribute' => 'preferred_username',
             'append_decoded_token' => false,
@@ -94,17 +95,7 @@ class TestCase extends Orchestra
         return [KeycloakGuardServiceProvider::class];
     }
 
-    // Just extract a string  from the public key, as required by config file
-    protected function plainPublicKey(): string
-    {
-        $string = str_replace('-----BEGIN PUBLIC KEY-----', '', $this->publicKey);
-        $string = trim(str_replace('-----END PUBLIC KEY-----', '', $string));
-        $string = str_replace('\n', '', $string);
-
-        return $string;
-    }
-
-    // Build a diferent token with custom payload
+    // Build a different token with custom payload
     protected function buildCustomToken(array $payload)
     {
         $payload = array_replace($this->payload, $payload);
@@ -113,10 +104,10 @@ class TestCase extends Orchestra
     }
 
     // Setup default token, for the default user
-     public function withKeycloakToken()
-     {
-         $this->withToken($this->token);
+    public function withKeycloakToken()
+    {
+        $this->withToken($this->token);
 
-         return $this;
-     }
+        return $this;
+    }
 }


### PR DESCRIPTION
As mentioned in #96, in cases where we have a user in our database, we can use Laravel's built-in actingAs method to act as a user for authentication. However, most of the time, our users are stored in Keycloak, so we just need a way to bypass the middleware.

This MR adds this feature to the package. There are some duplicated codes in test files and the trait that should be refactored. If the MR is acceptable, I can refactor it a bit.