### PR TITLE
feat: Consider input_key cookie for token

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ You can add a leeway to account for when there is a clock skew times between the
 
 _Default is `null`._
 
-By default this package **always** will look at first for a `Bearer` token. Additionally, if this option is enabled, then it will try to get a token from this custom request param.
+By default this package **always** will look at first for a `Bearer` token. Additionally, if this option is enabled, then it will try to get a token from this custom request param *or* cookie.
 
 ```php
 // keycloak.php
@@ -214,6 +214,17 @@ GET  $this->get("/foo/secret?api_token=xxxxx")
 POST $this->post("/foo/secret", ["api_token" => "xxxxx"])
 ```
 
+If there is neither a Bearer token nor a request parameter `api_token`, it will also accept a cookie with the name. This can be useful in case you protect an API that is used by client-side JavaScript. In that case, you can set an HttpOnly cookie holding the token:
+
+```php
+// Set the token as cookie
+return redirect($url)->withCookie(cookie($this->config['input_key'], $token, 3600, '/', null, true, true, true));
+```
+
+The browser then automatically sends the cookie along when performing requests to the API.*
+
+
+*\*Carefully consider Cross-Origin Resource Sharing (CORS) and the Same-Origin-Policy (SOP) when running into issues such as cookies not being sent along automatically.*
 
 # API
 

--- a/src/KeycloakGuard.php
+++ b/src/KeycloakGuard.php
@@ -58,7 +58,7 @@ class KeycloakGuard implements Guard
     {
         $inputKey = $this->config['input_key'] ?? "";
 
-        return $this->request->bearerToken() ?? $this->request->input($inputKey);
+        return $this->request->bearerToken() ?? $this->request->input($inputKey) ?? $this->request->cookies->get($inputKey);
     }
 
     /**
@@ -91,12 +91,12 @@ class KeycloakGuard implements Guard
         return !$this->check();
     }
 
-     /**
-     * Set the current user.
-     *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
-     * @return void
-     */
+    /**
+    * Set the current user.
+    *
+    * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+    * @return void
+    */
     public function setUser(Authenticatable $user)
     {
         $this->user = $user;
@@ -132,11 +132,11 @@ class KeycloakGuard implements Guard
         }
     }
 
-     /**
-     * Returns full decoded JWT token from athenticated user
-     *
-     * @return mixed|null
-     */
+    /**
+    * Returns full decoded JWT token from athenticated user
+    *
+    * @return mixed|null
+    */
     public function token()
     {
         return json_encode($this->decodedToken);
@@ -189,7 +189,7 @@ class KeycloakGuard implements Guard
         $allowed_resources = explode(',', $this->config['allowed_resources']);
 
         if (count(array_intersect($token_resource_access, $allowed_resources)) == 0) {
-            throw new ResourceAccessNotAllowedException("The decoded JWT token does not have a valid `resource_access` permission allowed by the API. Allowed resources: " . $this->config['allowed_resources'] . ". Token resources: " . json_encode($token_resource_access));
+            throw new ResourceAccessNotAllowedException("The decoded JWT token does not have a valid `resource_access` permission allowed by the API. Allowed resources: ".$this->config['allowed_resources'].". Token resources: ".json_encode($token_resource_access));
         }
     }
 
@@ -214,7 +214,7 @@ class KeycloakGuard implements Guard
 
         return false;
     }
-    
+
     /**
      * Check if authenticated user has a any role into resource
      * @param string $resource

--- a/tests/AuthenticateTest.php
+++ b/tests/AuthenticateTest.php
@@ -2,7 +2,6 @@
 
 namespace KeycloakGuard\Tests;
 
-use Firebase\JWT\JWT;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Hashing\BcryptHasher;
 use Illuminate\Support\Facades\Auth;
@@ -394,7 +393,7 @@ class AuthenticateTest extends TestCase
     {
         config(['keycloak.input_key' => "api_token"]);
 
-        $this->json('GET', '/foo/secret?api_token=' . $this->token);
+        $this->json('GET', '/foo/secret?api_token='.$this->token);
 
         $this->assertEquals(Auth::id(), $this->user->id);
 
@@ -410,6 +409,15 @@ class AuthenticateTest extends TestCase
         $this->assertEquals(Auth::id(), $this->user->id);
 
         $this->json('POST', '/foo/secret', ['api_token' => $this->token]);
+    }
+
+    public function test_authenticates_with_custom_input_key_cookie()
+    {
+        config(['keycloak.input_key' => "api_token"]);
+
+        $this->withKeycloakCookie('api_token')->json('GET', '/foo/secret');
+
+        $this->assertEquals(Auth::id(), $this->user->id);
     }
 
     public function test_acting_as_keycloak_user_trait()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -116,4 +116,12 @@ class TestCase extends Orchestra
 
         return $this;
     }
+
+    // Setup default token, for the default user
+    public function withKeycloakCookie($name)
+    {
+        $this->withCookie($name, $this->token);
+
+        return $this;
+    }
 }


### PR DESCRIPTION
https://github.com/robsontenorio/laravel-keycloak-guard/issues/118

Hey there! 

This is my first try to contribute to this project. Please note that for some reason my test does not work yet. Apparently, even though I added the  `withKeycloakCookie()` method, the cookie is not correctly set during the test run. Please excuse any inconveniences this may cause.

Best regards and have a great day,

Lauritz 