### PR TITLE
fix: Guard id() needs to support string identifiers for UUIDs

### DIFF
--- a/src/KeycloakGuard.php
+++ b/src/KeycloakGuard.php
@@ -107,9 +107,9 @@ class KeycloakGuard implements Guard
     /**
      * Get the ID for the currently authenticated user.
      */
-    public function id(): ?int
+    public function id(): int|string|null
     {
-        return $this->user()?->id;
+        return $this->user()?->getAuthIdentifier();
     }
 
     /**

--- a/tests/AuthenticateTest.php
+++ b/tests/AuthenticateTest.php
@@ -12,7 +12,9 @@ use KeycloakGuard\Exceptions\UserNotFoundException;
 use KeycloakGuard\KeycloakGuard;
 use KeycloakGuard\Tests\Extensions\CustomUserProvider;
 use KeycloakGuard\Tests\Factories\UserFactory;
+use KeycloakGuard\Tests\Factories\UuidUserFactory;
 use KeycloakGuard\Tests\Models\User;
+use KeycloakGuard\Tests\Models\UuidUser;
 use KeycloakGuard\Token;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -492,6 +494,26 @@ class AuthenticateTest extends TestCase
 
         $this->withKeycloakToken()->json('GET', '/foo/secret');
         $this->assertEquals($this->user->username, Auth::user()->username);
+    }
+
+    public function test_laravel_default_interface_for_authenticated_users_with_uuid_identifier()
+    {
+        $uuidUser = UuidUserFactory::new()->create([
+            'username' => 'johndoe-uuid',
+        ]);
+
+        config(['auth.providers.users.model' => UuidUser::class]);
+
+        $this->buildCustomToken([
+            'preferred_username' => 'johndoe-uuid',
+        ]);
+
+        $this->withKeycloakToken()->json('GET', '/foo/secret');
+
+        $this->assertEquals(Auth::hasUser(), true);
+        $this->assertEquals(Auth::guest(), false);
+        $this->assertIsString(Auth::id());
+        $this->assertEquals($uuidUser->id, Auth::id());
     }
 
     public static function scopeProvider(): array

--- a/tests/Extensions/UuidUserProvider.php
+++ b/tests/Extensions/UuidUserProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace KeycloakGuard\Tests\Extensions;
+
+use Illuminate\Auth\EloquentUserProvider;
+use KeycloakGuard\Tests\Models\UuidUser;
+
+class UuidUserProvider extends EloquentUserProvider
+{
+    public function custom_retrieve(object $token, array $credentials)
+    {
+        $user = new UuidUser();
+        $user->customRetrieve = true;
+
+        return $user;
+    }
+}

--- a/tests/Factories/UuidUserFactory.php
+++ b/tests/Factories/UuidUserFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace KeycloakGuard\Tests\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use KeycloakGuard\Tests\Models\UuidUser;
+
+class UuidUserFactory extends Factory
+{
+    protected $model = UuidUser::class;
+
+    public function definition(): array
+    {
+        return [
+            'id' => $this->faker->uuid(),
+            'username' => $this->faker->userName(),
+        ];
+    }
+}

--- a/tests/Models/UuidUser.php
+++ b/tests/Models/UuidUser.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace KeycloakGuard\Tests\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class UuidUser extends Authenticatable {
+    use HasUuids;
+
+    protected $table = "uuid_users";
+
+    protected $keyType = 'string';
+
+    public $incrementing = false;
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -102,6 +102,12 @@ class TestCase extends Orchestra
             $table->string('username');
             $table->timestamps();
         });
+
+        $app['db']->connection()->getSchemaBuilder()->create('uuid_users', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('username');
+            $table->timestamps();
+        });
     }
 
     // Build a different token with custom payload


### PR DESCRIPTION
This fixes KeycloakGuard::id() so it supports string based identifiers like e.g. UUIDs.

## Problem

Current implementation declares the return type as ?int, whereas the official implementation of laravel is 
/**
     * Get the ID for the currently authenticated user.
     *
     * @return int|string|null
     */
    public function id();

This means that UUID based ids cannot work with KeycloakGuard currently.

Additionally, Authenticable exposes the getAuthIdentifier() type which is the recommended way of getting the id of the entity without binding too hard to the implementation.

## Change
See code. Changed the KeycloakGuard#id method with the correct type declarations and trait usages.
I also added tests for this (fails without fix, passes with fix) - hope it aligns to the test design as wanted!